### PR TITLE
ndarray deep comparison fix.

### DIFF
--- a/hdf5storage/utilities.py
+++ b/hdf5storage/utilities.py
@@ -999,10 +999,10 @@ def deep_array_equal(a: Any, b: Any) -> bool:
         if a.shape != b.shape:
             return False
 
-        return all(deep_array_equal(x,y) for x,y in zip(a,b))
+        return all(deep_array_equal(x, y) for x, y in zip(a, b))
 
     # fallback to normal if dtype != object
-    return np.array_equal(a,b)
+    return np.array_equal(a, b)
 
 
 def convert_to_numpy_bytes(  # noqa: C901, PLR0911, PLR0912


### PR DESCRIPTION
This just changes the np.array_equal to a new version that works for ndarrays of ndarrays (object dtype) in set_attribute_all.

All tests pass, though this should probably have a new test to prevent regressions.